### PR TITLE
Use $(MAKE) to support parallel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,11 +441,11 @@ endif
 
 ifdef FFLAGS
 fast:
-	make main
-	make libqws.a
+	$(MAKE) main
+	$(MAKE) libqws.a
 else
 fast:
-	make main
+	$(MAKE) main
 endif
 
 DELIVERABLES=main libqws.a


### PR DESCRIPTION
Enables parallel build if you pass -j N to make so that building goes faster.