### PR TITLE
remove unnecessary confidential designations

### DIFF
--- a/avx512_intrin.hh
+++ b/avx512_intrin.hh
@@ -47,7 +47,6 @@
 //  using the Supercomputer Fugaku.
 //
 //****************************************************************************************
-// FUJITSU CONFIDENTIAL info for target apps for priority issues(Detailed Design(4))
 
 #pragma once
 

--- a/sve_intrin.hh
+++ b/sve_intrin.hh
@@ -47,7 +47,6 @@
 //  using the Supercomputer Fugaku.
 //
 //****************************************************************************************
-// FUJITSU CONFIDENTIAL info for target apps for priority issues(Detailed Design(4))
 
 #pragma once
 


### PR DESCRIPTION
富士通の向井です。ご無沙汰しております。
公開することに決まったコードに秘密表示が残ってしまっているようですので削除をお願いします。
